### PR TITLE
Add data and restructure file handling

### DIFF
--- a/projects/babies_r_us/babies_model.py
+++ b/projects/babies_r_us/babies_model.py
@@ -1,0 +1,125 @@
+import argparse
+
+import pandas as pd
+import numpy as np
+from sklearn.metrics import root_mean_squared_log_error
+import matplotlib.pyplot as plt
+import itertools
+import lightning as L
+import os
+
+from tabgpt.callbacks import whole_epoch_train_loss
+from tabgpt.data.babies_r_us.data_setup import BabiesData
+from tabgpt.data.favorita.data_setup import FavoritaData
+from tabgpt.model_hf import tabGPT_HF, tabGPTConfig
+from tabgpt.tabular_dataset import TabularDataset, load_datasets
+from tabgpt.utils import evaluation, predict
+import torch
+from torch.utils.data import TensorDataset, DataLoader
+
+
+from tabgpt.trainer import Trainer
+from tabgpt.col_embed import Embedder
+
+from IPython import embed
+
+import logging
+
+logging.getLogger("transformers").setLevel(logging.ERROR)
+
+
+if torch.cuda.is_available():
+    device = torch.device("cuda:0")
+    print("Using GPU.")
+else:
+    print("No GPU available, using the CPU instead.")
+    device = torch.device("cpu")
+
+
+if __name__ == '__main__':
+
+    pretrained_model_path = './pretrained_babies_model'
+
+    fd = BabiesData()
+    fd.setup() # only test
+    emb = Embedder(fd)
+
+    in_memory = False
+    files_generated = False # only used in file-approach
+
+    if in_memory:
+        print('Generate embedding and load into memory')
+        # in-memory approach (re-run every time)
+        emb.train()
+        f_embeds_train = emb.embed(n_cols=fd.n_features)
+        emb.val()
+        f_embeds_val = emb.embed(n_cols=fd.n_features)
+
+    else:
+        # file-approach (only need to run once)
+        if not files_generated:
+            print('Storing data as files')
+            emb.train()
+            emb.embed(n_cols=fd.n_features,save=True)
+            emb.val()
+            emb.embed(n_cols=fd.n_features,save=True)
+    
+
+    print(f'train samples: {len(fd.df_train)}')
+
+    n_layer, n_head = 4, 4 # gpt-micro
+    config = tabGPTConfig(n_layer=n_layer, n_head=n_head, block_size=fd.n_features + 1, n_output_nodes=1)
+    model = tabGPT_HF(config)
+
+    target_column = fd.main_target
+    train_targets = fd.df_train[fd.main_target]
+    val_targets = fd.df_val[fd.main_target]
+    target_scaler = fd.scaler[target_column]
+
+    df_train = fd.df_train
+    df_val = fd.df_val
+
+
+    if in_memory:
+        train_dataset = TensorDataset(
+            f_embeds_train,
+            torch.tensor(train_targets.tolist(), dtype=torch.float32)
+            )
+    else:
+        train_dataset =  load_datasets(dataset_loader=[fd], mode='train',target=target_column)
+
+
+    train_config = Trainer.get_default_config()
+    train_config.epochs = 1
+    train_config.num_workers = 0
+    train_config.batch_size = 64
+    train_config.learning_rate = 5e-4
+    trainer = Trainer(train_config, model, train_dataset)
+
+    trainer.run()
+
+    print("Storing trained model")
+    os.makedirs(pretrained_model_path, exist_ok=True)
+    model.save_pretrained(pretrained_model_path)
+
+    # inference
+    df_train[target_column] = target_scaler.inverse_transform(df_train[[target_column]])
+
+    df_train = predict(model, DataLoader(train_dataset, batch_size=32), fd.df_train, target_scaler=target_scaler)
+    evaluation(df_train[target_column], df_train["yhat"])
+
+    if in_memory:
+        val_dataset = TensorDataset(
+            f_embeds_val,
+            torch.tensor(val_targets.tolist(), dtype=torch.float32)
+        )
+    else:
+        val_dataset =  load_datasets(dataset_loader=[fd], mode='val', target=target_column)
+
+
+    df_val[target_column] = target_scaler.inverse_transform(df_val[[target_column]])
+
+    df_val = predict(model, DataLoader(val_dataset, batch_size=32), fd.df_val, target_scaler=target_scaler)
+    evaluation(df_val[target_column], df_val["yhat"])
+
+

--- a/projects/buybuy_babies/buy-baby-model.py
+++ b/projects/buybuy_babies/buy-baby-model.py
@@ -1,0 +1,122 @@
+import argparse
+
+import pandas as pd
+import numpy as np
+from sklearn.metrics import root_mean_squared_log_error
+import matplotlib.pyplot as plt
+import itertools
+import lightning as L
+import os
+
+from tabgpt.callbacks import whole_epoch_train_loss
+from tabgpt.data.buybuy_baby.data_setup import BuyBuyBabyData
+from tabgpt.model_hf import tabGPT_HF, tabGPTConfig
+from tabgpt.tabular_dataset import load_datasets
+from tabgpt.utils import evaluation, predict
+import torch
+from torch.utils.data import TensorDataset, DataLoader
+
+
+from tabgpt.trainer import Trainer
+from tabgpt.col_embed import Embedder
+
+from IPython import embed
+
+import logging
+
+logging.getLogger("transformers").setLevel(logging.ERROR)
+
+
+if torch.cuda.is_available():
+    device = torch.device("cuda:0")
+    print("Using GPU.")
+else:
+    print("No GPU available, using the CPU instead.")
+    device = torch.device("cpu")
+
+
+if __name__ == '__main__':
+
+    pretrained_model_path = './pretrained_buybuy_babies_model'
+
+    fd = BuyBuyBabyData()
+    fd.setup() # only test
+    emb = Embedder(fd)
+
+    in_memory = False
+    files_generated = False # only used in file-approach
+
+    if in_memory:
+        print('Generate embedding and load into memory')
+        # in-memory approach (re-run every time)
+        emb.train()
+        f_embeds_train = emb.embed(n_cols=fd.n_features)
+        emb.val()
+        f_embeds_val = emb.embed(n_cols=fd.n_features)
+
+    else:
+        # file-approach (only need to run once)
+        if not files_generated:
+            print('Storing data as files')
+            emb.train()
+            emb.embed(n_cols=fd.n_features,save=True)
+            emb.val()
+            emb.embed(n_cols=fd.n_features,save=True)
+    
+
+    print(f'train samples: {len(fd.df_train)}')
+
+    n_layer, n_head = 4, 4 # gpt-micro
+    config = tabGPTConfig(n_layer=n_layer, n_head=n_head, block_size=fd.n_features + 1, n_output_nodes=1)
+    model = tabGPT_HF(config)
+
+    target_column = fd.main_target
+    train_targets = fd.df_train[fd.main_target]
+    val_targets = fd.df_val[fd.main_target]
+    target_scaler = fd.scaler[target_column]
+
+    df_train = fd.df_train
+    df_val = fd.df_val
+
+
+    if in_memory:
+        train_dataset = TensorDataset(
+            f_embeds_train,
+            torch.tensor(train_targets.tolist(), dtype=torch.float32)
+            )
+    else:
+        train_dataset =  load_datasets(dataset_loader=[fd], mode='train',target=target_column)
+
+
+    train_config = Trainer.get_default_config()
+    train_config.epochs = 1
+    train_config.num_workers = 0
+    train_config.batch_size = 64
+    train_config.learning_rate = 5e-4
+    trainer = Trainer(train_config, model, train_dataset)
+
+    trainer.run()
+
+    print("Storing trained model")
+    os.makedirs(pretrained_model_path, exist_ok=True)
+    model.save_pretrained(pretrained_model_path)
+
+    # inference
+    df_train[target_column] = target_scaler.inverse_transform(df_train[[target_column]])
+
+    df_train = predict(model, DataLoader(train_dataset, batch_size=32), fd.df_train, target_scaler=target_scaler)
+    evaluation(df_train[target_column], df_train["yhat"])
+
+    if in_memory:
+        val_dataset = TensorDataset(
+            f_embeds_val,
+            torch.tensor(val_targets.tolist(), dtype=torch.float32)
+        )
+    else:
+        val_dataset =  load_datasets(dataset_loader=[fd], mode='val', target=target_column)
+
+
+    df_val[target_column] = target_scaler.inverse_transform(df_val[[target_column]])
+
+    df_val = predict(model, DataLoader(val_dataset, batch_size=32), fd.df_val, target_scaler=target_scaler)
+    evaluation(df_val[target_column], df_val["yhat"])

--- a/projects/favorita/favorita_model.py
+++ b/projects/favorita/favorita_model.py
@@ -1,0 +1,124 @@
+import argparse
+
+import pandas as pd
+import numpy as np
+from sklearn.metrics import root_mean_squared_log_error
+import matplotlib.pyplot as plt
+import itertools
+import lightning as L
+import os
+
+from tabgpt.callbacks import whole_epoch_train_loss
+from tabgpt.data.favorita.data_setup import FavoritaData
+from tabgpt.model_hf import tabGPT_HF, tabGPTConfig
+from tabgpt.tabular_dataset import TabularDataset, load_datasets
+from tabgpt.utils import evaluation, predict
+import torch
+from torch.utils.data import TensorDataset, DataLoader
+
+
+from tabgpt.trainer import Trainer
+from tabgpt.col_embed import Embedder
+
+from IPython import embed
+
+import logging
+
+logging.getLogger("transformers").setLevel(logging.ERROR)
+
+
+if torch.cuda.is_available():
+    device = torch.device("cuda:0")
+    print("Using GPU.")
+else:
+    print("No GPU available, using the CPU instead.")
+    device = torch.device("cpu")
+
+
+if __name__ == '__main__':
+
+    pretrained_model_path = './pretrained_favorita_model'
+
+    fd = FavoritaData()
+    fd.setup(last_nrows=1000) # only test
+    emb = Embedder(fd)
+
+    in_memory = False
+    files_generated = True
+
+    if in_memory:
+        print('Generate embedding and load into memory')
+        # in-memory approach (re-run every time)
+        emb.train()
+        f_embeds_train = emb.embed(n_cols=fd.n_features)
+        emb.val()
+        f_embeds_val = emb.embed(n_cols=fd.n_features)
+
+    else:
+        # file-approach (only need to run once)
+        if not files_generated:
+            print('Storing data as files')
+            emb.train()
+            emb.embed(n_cols=fd.n_features,save=True)
+            emb.val()
+            emb.embed(n_cols=fd.n_features,save=True)
+    
+
+    print(f'train samples: {len(fd.df_train)}')
+
+    n_layer, n_head = 4, 4 # gpt-micro
+    config = tabGPTConfig(n_layer=n_layer, n_head=n_head, block_size=fd.n_features + 1, n_output_nodes=1)
+    model = tabGPT_HF(config)
+
+    target_column = fd.main_target
+    train_targets = fd.df_train[fd.main_target]
+    val_targets = fd.df_val[fd.main_target]
+    target_scaler = fd.scaler[target_column]
+
+    df_train = fd.df_train
+    df_val = fd.df_val
+
+
+    if in_memory:
+        train_dataset = TensorDataset(
+            f_embeds_train,
+            torch.tensor(train_targets.tolist(), dtype=torch.float32)
+            )
+    else:
+        train_dataset =  load_datasets(dataset_loader=[fd], mode='train', target=target_column)
+
+
+    train_config = Trainer.get_default_config()
+    train_config.epochs = 1
+    train_config.num_workers = 0
+    train_config.batch_size = 64
+    train_config.learning_rate = 5e-4
+    trainer = Trainer(train_config, model, train_dataset)
+
+    trainer.run()
+
+    print("Storing trained model")
+    os.makedirs(pretrained_model_path, exist_ok=True)
+    model.save_pretrained(pretrained_model_path)
+
+    # inference
+    df_train[target_column] = target_scaler.inverse_transform(df_train[[target_column]])
+
+    df_train = predict(model, DataLoader(train_dataset, batch_size=32), fd.df_train, target_scaler=target_scaler)
+    evaluation(df_train[target_column], df_train["yhat"])
+
+    if in_memory:
+        val_dataset = TensorDataset(
+            f_embeds_val,
+            torch.tensor(val_targets.tolist(), dtype=torch.float32)
+        )
+    else:
+        val_dataset =  load_datasets(dataset_loader=[fd], mode='val', target=target_column)
+
+
+    df_val[target_column] = target_scaler.inverse_transform(df_val[[target_column]])
+
+    df_val = predict(model, DataLoader(val_dataset, batch_size=32), fd.df_val, target_scaler=target_scaler)
+    evaluation(df_val[target_column], df_val["yhat"])
+
+

--- a/projects/rossmann/rossmann_model.py
+++ b/projects/rossmann/rossmann_model.py
@@ -1,0 +1,128 @@
+import argparse
+
+import pandas as pd
+import numpy as np
+from sklearn.metrics import root_mean_squared_log_error
+import matplotlib.pyplot as plt
+import itertools
+import lightning as L
+import os
+
+from tabgpt.callbacks import whole_epoch_train_loss
+from tabgpt.data.rossmann.data_setup import RossmannData
+from tabgpt.model_hf import tabGPT_HF, tabGPTConfig
+from tabgpt.tabular_dataset import TabularDataset, load_datasets
+from tabgpt.utils import evaluation, predict
+import torch
+from torch.utils.data import TensorDataset, DataLoader
+
+
+from tabgpt.trainer import Trainer
+from tabgpt.col_embed import Embedder
+
+from IPython import embed
+
+import logging
+
+logging.getLogger("transformers").setLevel(logging.ERROR)
+
+
+if torch.cuda.is_available():
+    device = torch.device("cuda:0")
+    print("Using GPU.")
+else:
+    print("No GPU available, using the CPU instead.")
+    device = torch.device("cpu")
+
+
+if __name__ == '__main__':
+
+    pretrained_model_path = './pretrained_rossmann_model'
+
+    rm = RossmannData()
+    rm.setup(last_nrows=1000) # only test
+    print(rm)
+    emb = Embedder(rm)
+
+    embed()
+
+    in_memory = False
+    files_generated = False # only used in file-approach
+
+    if in_memory:
+        print('Generate embedding and load into memory')
+        # in-memory approach (re-run every time)
+        emb.train()
+        f_embeds_train = emb.embed(n_cols=rm.n_features)
+        emb.val()
+        f_embeds_val = emb.embed(n_cols=rm.n_features)
+
+    else:
+        # file-approach (only need to run once)
+        if not files_generated:
+            print('Storing data as files')
+            emb.train()
+            emb.embed(n_cols=rm.n_features,save=True)
+            emb.val()
+            emb.embed(n_cols=rm.n_features,save=True)
+    
+
+    print(f'train samples: {len(rm.df_train)}')
+
+    n_layer, n_head = 4, 4 # gpt-micro
+    config = tabGPTConfig(n_layer=n_layer, n_head=n_head, block_size=rm.n_features + 1, n_output_nodes=1)
+    model = tabGPT_HF(config)
+
+    target_column = rm.main_target
+    train_targets = rm.df_train[rm.main_target]
+    val_targets = rm.df_val[rm.main_target]
+    target_scaler = rm.scaler[target_column]
+
+    df_train = rm.df_train
+    df_val = rm.df_val
+
+
+    if in_memory:
+        train_dataset = TensorDataset(
+            f_embeds_train,
+            torch.tensor(train_targets.tolist(), dtype=torch.float32)
+            )
+    else:
+        train_dataset =  load_datasets(dataset_loader=[rm], mode='train')
+
+
+    train_config = Trainer.get_default_config()
+    train_config.epochs = 1
+    train_config.num_workers = 0
+    train_config.batch_size = 64
+    train_config.learning_rate = 5e-4
+    trainer = Trainer(train_config, model, train_dataset)
+
+    trainer.run()
+
+    print("Storing trained model")
+    os.makedirs(pretrained_model_path, exist_ok=True)
+    model.save_pretrained(pretrained_model_path)
+
+    # inference
+    df_train[target_column] = target_scaler.inverse_transform(df_train[[target_column]])
+
+    evaluate_train_dataset = load_datasets(dataset_loader=[rm], mode='train', only_main=True)
+    df_train = predict(model, DataLoader(evaluate_train_dataset, batch_size=32), rm.df_train, target_scaler=target_scaler)
+    evaluation(df_train[target_column], df_train["yhat"])
+
+    if in_memory:
+        val_dataset = TensorDataset(
+            f_embeds_val,
+            torch.tensor(val_targets.tolist(), dtype=torch.float32)
+        )
+    else:
+        val_dataset =  load_datasets(dataset_loader=[rm], mode='val', only_main=True)
+
+
+    df_val[target_column] = target_scaler.inverse_transform(df_val[[target_column]])
+
+    df_val = predict(model, DataLoader(val_dataset, batch_size=32), rm.df_val, target_scaler=target_scaler)
+    evaluation(df_val[target_column], df_val["yhat"])
+
+

--- a/projects/walmart/walmart_model.py
+++ b/projects/walmart/walmart_model.py
@@ -1,0 +1,124 @@
+import argparse
+
+import pandas as pd
+import numpy as np
+from sklearn.metrics import root_mean_squared_log_error
+import matplotlib.pyplot as plt
+import itertools
+import lightning as L
+import os
+
+from tabgpt.callbacks import whole_epoch_train_loss
+from tabgpt.data.walmart.data_setup import WalmartData
+from tabgpt.model_hf import tabGPT_HF, tabGPTConfig
+from tabgpt.tabular_dataset import TabularDataset, load_datasets
+from tabgpt.utils import evaluation, predict
+import torch
+from torch.utils.data import TensorDataset, DataLoader
+
+
+from tabgpt.trainer import Trainer
+from tabgpt.col_embed import Embedder
+
+from IPython import embed
+
+import logging
+
+logging.getLogger("transformers").setLevel(logging.ERROR)
+
+
+if torch.cuda.is_available():
+    device = torch.device("cuda:0")
+    print("Using GPU.")
+else:
+    print("No GPU available, using the CPU instead.")
+    device = torch.device("cpu")
+
+
+if __name__ == '__main__':
+
+    pretrained_model_path = './pretrained_walmart_model'
+
+    wm = WalmartData()
+    wm.setup(last_nrows=1000) # only test
+    emb = Embedder(wm)
+
+    in_memory = False
+    files_generated = False # only used in file-approach
+
+    if in_memory:
+        print('Generate embedding and load into memory')
+        # in-memory approach (re-run every time)
+        emb.train()
+        f_embeds_train = emb.embed(n_cols=wm.n_features)
+        emb.val()
+        f_embeds_val = emb.embed(n_cols=wm.n_features)
+
+    else:
+        # file-approach (only need to run once)
+        if not files_generated:
+            print('Storing data as files')
+            emb.train()
+            emb.embed(n_cols=wm.n_features,save=True)
+            emb.val()
+            emb.embed(n_cols=wm.n_features,save=True)
+    
+
+    print(f'train samples: {len(wm.df_train)}')
+
+    n_layer, n_head = 4, 4 # gpt-micro
+    config = tabGPTConfig(n_layer=n_layer, n_head=n_head, block_size=wm.n_features + 1, n_output_nodes=1)
+    model = tabGPT_HF(config)
+
+    target_column = wm.main_target
+    train_targets = wm.df_train[wm.main_target]
+    val_targets = wm.df_val[wm.main_target]
+    target_scaler = wm.scaler[target_column]
+
+    df_train = wm.df_train
+    df_val = wm.df_val
+
+
+    if in_memory:
+        train_dataset = TensorDataset(
+            f_embeds_train,
+            torch.tensor(train_targets.tolist(), dtype=torch.float32)
+            )
+    else:
+        train_dataset =  load_datasets(dataset_loader=[wm], mode='train', target=target_column)
+
+
+    train_config = Trainer.get_default_config()
+    train_config.epochs = 1
+    train_config.num_workers = 0
+    train_config.batch_size = 64
+    train_config.learning_rate = 5e-4
+    trainer = Trainer(train_config, model, train_dataset)
+
+    trainer.run()
+
+    print("Storing trained model")
+    os.makedirs(pretrained_model_path, exist_ok=True)
+    model.save_pretrained(pretrained_model_path)
+
+    # inference
+    df_train[target_column] = target_scaler.inverse_transform(df_train[[target_column]])
+
+    df_train = predict(model, DataLoader(train_dataset, batch_size=32), wm.df_train, target_scaler=target_scaler)
+    evaluation(df_train[target_column], df_train["yhat"])
+
+    if in_memory:
+        val_dataset = TensorDataset(
+            f_embeds_val,
+            torch.tensor(val_targets.tolist(), dtype=torch.float32)
+        )
+    else:
+        val_dataset =  load_datasets(dataset_loader=[wm], mode='val', target=target_column)
+
+
+    df_val[target_column] = target_scaler.inverse_transform(df_val[[target_column]])
+
+    df_val = predict(model, DataLoader(val_dataset, batch_size=32), wm.df_val, target_scaler=target_scaler)
+    evaluation(df_val[target_column], df_val["yhat"])
+
+

--- a/tabgpt/data/babies_r_us/data_setup.py
+++ b/tabgpt/data/babies_r_us/data_setup.py
@@ -1,0 +1,95 @@
+from tabgpt.data_loader import DataFrameLoader
+import pandas as pd
+import numpy as np
+import os
+import re
+from sklearn.model_selection import train_test_split
+
+from IPython import embed
+
+
+class BabiesData(DataFrameLoader):
+    def __init__(self, task_description='babies r us products'):
+        super().__init__(task_description)
+
+    def setup(self, last_nrows=50_000):
+
+        df = pd.read_csv(os.path.join(self.current_dir, 'babies_r_us.csv'))
+     
+
+        df['weight'] = df['weight'].apply(self.convert_to_pounds)
+        df['length'] = df['length'].apply(self.convert_to_inches)
+        df['width'] = df['width'].apply(self.convert_to_inches)
+        df['height'] = df['height'].apply(self.convert_to_inches)
+
+
+        df = df.assign(is_discounted=lambda df: df.is_discounted.map({1: "yes", 0: "no"}))
+
+        df_train, df_val = train_test_split(df, test_size=0.2, random_state=666)
+        
+        cat_features = ['int_id', 'ext_id', 'title', 'SKU', 'is_discounted','category', 'company_struct', 'company_free', 'brand', 'fabrics', 'colors', 'materials']
+        
+        num_features = ['weight', 'length', 'width', 'height']
+
+        self.setup_scaler(num_features)
+        self.scale_columns(df_train, mode='train')
+        self.scale_columns(df_val)
+
+        self.df_train = df_train
+        self.df_val = df_val
+        self.numerical_features = num_features
+        self.categorical_features = cat_features
+        self.n_features = len(cat_features + num_features)
+        self.set_target_column(main_target='price', additional_ones=False)
+
+    def convert_to_pounds(self, value):
+        # Handle missing values (nan)
+        if pd.isna(value):
+            return np.nan
+        
+        # Remove commas and periods from the string (except for decimal points)
+        value = str(value)
+        value = value.replace(',', '').replace('.', '').replace('oz', ' oz').replace('lbs', ' lbs').replace('lb', ' lb')
+        
+        # Initialize pounds and ounces to 0
+        pounds = 0.0
+        ounces = 0.0
+        
+        # Find pounds
+        pound_match = re.search(r'(\d+(\.\d+)?)\s*lb', value)
+        if pound_match:
+            pounds = float(pound_match.group(1))
+        
+        # Find ounces
+        ounce_match = re.search(r'(\d+(\.\d+)?)\s*oz', value)
+        if ounce_match:
+            ounces = float(ounce_match.group(1))
+        
+        # Convert ounces to pounds and add to pounds
+        pounds += ounces / 16.0
+        
+        return pounds
+        
+    def convert_to_inches(self, value):
+        # Handle missing values
+        if pd.isna(value):
+            return np.nan
+        
+        # Remove any non-numeric values (catch words, symbols)
+        if not re.search(r'\d', value):
+            return np.nan
+        
+        # Clean up the string (remove unwanted characters like ", in, etc.)
+        value = re.sub(r'[^0-9.]', '', value)
+        
+        # If value is empty after removing non-numeric characters, set to NaN
+        if value == '':
+            return np.nan
+        
+        # Convert to float
+        try:
+            return float(value)
+        except ValueError:
+            return np.nan
+
+

--- a/tabgpt/data/buybuy_baby/data_setup.py
+++ b/tabgpt/data/buybuy_baby/data_setup.py
@@ -1,0 +1,91 @@
+from tabgpt.data_loader import DataFrameLoader
+import pandas as pd
+import numpy as np
+import os
+import re
+from sklearn.model_selection import train_test_split
+
+from IPython import embed
+
+
+class BuyBuyBabyData(DataFrameLoader):
+    def __init__(self, task_description='buybuy baby products'):
+        super().__init__(task_description)
+
+    def setup(self):
+        df = pd.read_csv(os.path.join(self.current_dir, 'buy_buy_baby.csv'))
+     
+
+        df['weight'] = df['weight'].apply(self.convert_to_pounds)
+        df['length'] = df['length'].apply(self.convert_to_inches)
+        df['width'] = df['width'].apply(self.convert_to_inches)
+        df['height'] = df['height'].apply(self.convert_to_inches)
+
+        df_train, df_val = train_test_split(df, test_size=0.2, random_state=666)
+        
+        cat_features = ['title', 'is_discounted','category', 'company_struct', 'company_free', 'brand', 'fabrics', 'colors', 'materials']
+        
+        num_features = ['weight', 'length', 'width', 'height']
+
+        self.setup_scaler(num_features)
+        self.scale_columns(df_train, mode='train')
+        self.scale_columns(df_val)
+
+        self.df_train = df_train
+        self.df_val = df_val
+        self.numerical_features = num_features
+        self.categorical_features = cat_features
+        self.n_features = len(cat_features + num_features)
+        self.set_target_column(main_target='price', additional_ones=False)
+
+    def convert_to_pounds(self, value):
+        # Handle missing values (nan)
+        if pd.isna(value):
+            return np.nan
+        
+        # Remove commas and periods from the string (except for decimal points)
+        value = str(value)
+        value = value.replace(',', '').replace('.', '').replace('oz', ' oz').replace('lbs', ' lbs').replace('lb', ' lb')
+        
+        # Initialize pounds and ounces to 0
+        pounds = 0.0
+        ounces = 0.0
+        
+        # Find pounds
+        pound_match = re.search(r'(\d+(\.\d+)?)\s*lb', value)
+        if pound_match:
+            pounds = float(pound_match.group(1))
+        
+        # Find ounces
+        ounce_match = re.search(r'(\d+(\.\d+)?)\s*oz', value)
+        if ounce_match:
+            ounces = float(ounce_match.group(1))
+        
+        # Convert ounces to pounds and add to pounds
+        pounds += ounces / 16.0
+        
+        return pounds
+        
+    def convert_to_inches(self, value):
+        # Handle missing values
+        if pd.isna(value):
+            return np.nan
+        
+        # Remove any non-numeric values (catch words, symbols)
+        if not re.search(r'\d', value):
+            return np.nan
+        
+        # Clean up the string (remove unwanted characters like ", in, etc.)
+        value = re.sub(r'[^0-9.]', '', value)
+        
+        # If value is empty after removing non-numeric characters, set to NaN
+        if value == '':
+            return np.nan
+        
+        # Convert to float
+        try:
+            return float(value)
+        except ValueError:
+            return np.nan
+
+

--- a/tabgpt/data/favorita/data_setup.py
+++ b/tabgpt/data/favorita/data_setup.py
@@ -1,0 +1,74 @@
+from tabgpt.data_loader import DataFrameLoader
+import pandas as pd
+import numpy as np
+import os
+from sklearn.model_selection import train_test_split
+
+from tabgpt.utils import stratify
+
+
+class FavoritaData(DataFrameLoader):
+    def __init__(self, task_description='favorita store products'):
+        super().__init__(task_description)
+
+    def setup(self, last_nrows=50_000):
+        col_dict = {
+        "store_nbr": "unique store id",
+        "item_nbr": "unique item number",
+        "unit_sales": "Sales",
+        "onpromotion": "product is in promotion",
+        "family": "product type",
+        "class": "product class",
+        "perishable": "product is perishable",
+        "transferred": "holiday transferred to other day",
+        "day_of_week": "day of the week",
+        }
+
+        df_train = pd.read_csv(
+            os.path.join(self.current_dir,"train.csv"),
+            parse_dates=["date"],
+            skiprows=range(1, 124600000),
+        )  # result ~ 800.000 rows
+        items = pd.read_csv(os.path.join(self.current_dir,"items.csv"))
+        df_holiday_events = pd.read_csv(os.path.join(self.current_dir,"holidays_events.csv"))
+        df_holiday_events["date"] = pd.to_datetime(df_holiday_events["date"])
+        df = df_train.merge(items, how="left", on="item_nbr")
+        df = df.merge(df_holiday_events, how="left", on="date")
+        df["month"] = df["date"].dt.month_name()
+        df["year"] = df["date"].dt.year
+        df["day_of_week"] = df["date"].dt.day_name()
+        df.drop(["date"], axis=1, inplace=True)
+
+        df = df[df["unit_sales"] >= 0]
+
+        df.drop(["id"], axis=1, inplace=True)
+
+        df = df.assign(
+            onpromotion=lambda df: df.onpromotion.map({False: "no", True: "yes"})
+        ).assign(perishable=lambda df: df.perishable.map({0: "no", 1: "yes"}))
+
+
+        # family -> product type
+        df = stratify(df,groupby_cols=['family'])
+        df = df.rename(columns=col_dict)
+
+        df_train, df_val = train_test_split(df,test_size=0.1,stratify=df[['product type']])
+
+        categorical_features = df_train.columns[df_train.columns != "Sales"].tolist()
+        numerical_features = ['Sales']
+
+        self.setup_scaler(numerical_features)
+        self.scale_columns(df_train, mode='train')
+        self.scale_columns(df_val)
+
+        self.df_train = df_train
+        self.df_val = df_val
+        self.numerical_features = numerical_features
+        self.categorical_features = categorical_features
+        self.n_features = len(categorical_features + numerical_features)
+        self.set_target_column(main_target='Sales',additional_ones=False)
+
+
+
+
+

--- a/tabgpt/data/rossmann/data_setup.py
+++ b/tabgpt/data/rossmann/data_setup.py
@@ -1,0 +1,114 @@
+from tabgpt.data_loader import DataFrameLoader
+import pandas as pd
+import numpy as np
+import os
+from sklearn.model_selection import train_test_split
+
+from tabgpt.utils import stratify
+
+
+class RossmannData(DataFrameLoader):
+    def __init__(self, task_description='Rossmann store products'):
+        super().__init__(task_description)
+
+    def setup(self, last_nrows=50_000):
+        col_dict = {
+        "Store": "unique store Id",
+        "Customers": "number of customers",
+        "DayOfWeek": "day of the week",
+        "Open": "was the store open",
+        "StateHoliday": "indicates a state holiday",
+        "SchoolHoliday": "affected by school holidays",
+        "StoreType": "type of store",
+        "Assortment": "assortment level",
+        "CompetitionDistance": "distance in meters to the nearest competitor store",
+        "Promo": "product is in promotion",
+        "Promo2": "special promotion",
+        }
+
+        stores = pd.read_csv(os.path.join(self.current_dir,"store.csv"))
+        df = (
+            pd.read_csv(os.path.join(self.current_dir,"train.csv"), parse_dates=True)
+            .assign(
+                StateHoliday=lambda df: df.StateHoliday.map(
+                    {
+                        "a": "public holiday",
+                        "b": "Easter holiday",
+                        "c": "Christmas",
+                        "0": "none",
+                        0: "none",
+                    }
+                )
+            )
+            .merge(stores, how="left", on="Store")
+            .sort_values(["Store", "Date"])
+            .assign(
+                Assortment=lambda df: df.Assortment.map(
+                    {"a": "basic", "b": "extra", "c": "extended"}
+                )
+            )
+            .assign(Open=lambda df: df.Open.map({0: "closed", 1: "open"}))
+            .assign(Promo=lambda df: df.Promo.map({0: "no", 1: "yes"}))
+            .assign(SchoolHoliday=lambda df: df.SchoolHoliday.map({0: "no", 1: "yes"}))
+            .assign(
+                Promo2=lambda df: df.Promo2.map(
+                    {0: "not participating", 1: "participating"}
+                )
+            )
+            .assign(
+                StoreType=lambda df: df.StoreType.map(
+                    {"a": "Type A", "b": "Type B", "c": "Type C", "d": "Type D"}
+                )
+            )
+            .assign(
+                DayOfWeek=lambda df: df.DayOfWeek.map(
+                    {
+                        1: "Monday",
+                        2: "Tuesday",
+                        3: "Wednesday",
+                        4: "Thursday",
+                        5: "Friday",
+                        6: "Saturday",
+                        7: "Sunday",
+                    }
+                )
+            )
+            .drop([c for c in stores.columns if c.startswith("Competition")], axis=1)
+            .drop([c for c in stores.columns if c.startswith("Promo2S")], axis=1)
+            .drop(["PromoInterval", "StoreType", "Assortment"], axis=1)
+        )
+
+        df = df[(df["Open"] == "open") & (df["Sales"] != 0)]
+        df.drop(["Open"], axis=1, inplace=True)
+
+        df["Date"] = pd.to_datetime(df["Date"])
+
+        df["month"] = df["Date"].dt.month_name()
+        df["year"] = df["Date"].dt.year
+        df.drop(["Date"], axis=1, inplace=True)
+
+        # Store -> unique store Id
+        df = stratify(df,groupby_cols=['Store'])
+        df = df.rename(columns=col_dict)
+
+        df_train, df_val = train_test_split(df,test_size=0.1,stratify=df[['unique store Id']])
+
+        categorical_features = df_train.columns[
+            (df_train.columns != "Sales") & (df_train.columns != "number of customers")
+        ].tolist()
+        numerical_features = ["Sales", "number of customers"]
+
+        self.setup_scaler(numerical_features)
+        self.scale_columns(df_train, mode='train')
+        self.scale_columns(df_val)
+
+        self.df_train = df_train
+        self.df_val = df_val
+        self.numerical_features = numerical_features
+        self.categorical_features = categorical_features
+        self.set_target_column(main_target='Sales', additional_ones=True)
+
+
+
+
+

--- a/tabgpt/data/walmart/data_setup.py
+++ b/tabgpt/data/walmart/data_setup.py
@@ -1,0 +1,88 @@
+from tabgpt.data_loader import DataFrameLoader
+import pandas as pd
+import numpy as np
+import os
+from sklearn.model_selection import train_test_split
+
+from tabgpt.utils import stratify
+
+
+class WalmartData(DataFrameLoader):
+    def __init__(self, task_description='Walmart store products'):
+        super().__init__(task_description)
+
+    def setup(self, last_nrows=50_000):
+        col_dict = {
+        "Dept": "department number",
+        "Store": "store number",
+        "Fuel_Price": "cost of fuel",
+        "CPI": "consumer price index",
+        "Unemployment": "unemployment rate",
+        "IsHoliday": "special holiday week",
+        "Size": "store size (in square feet)",
+        "Temperature": "average temperature (in Fahrenheit)",
+        }
+
+        dataset = pd.read_csv(os.path.join(self.current_dir,"train.csv"))
+        features = pd.read_csv(os.path.join(self.current_dir,"features.csv"))
+        stores = pd.read_csv(os.path.join(self.current_dir,"stores.csv"))
+        features = features.merge(stores, how="inner", on="Store")
+        df = (
+            dataset.merge(features, how="inner", on=["Store", "Date", "IsHoliday"])
+            .sort_values(by=["Store", "Dept", "Date"])
+            .reset_index(drop=True)
+        )
+
+        df["Date"] = pd.to_datetime(df["Date"])
+
+        df["month"] = df["Date"].dt.month_name()
+        df["year"] = df["Date"].dt.year
+        df["week"] = df["Date"].dt.isocalendar().week
+
+        df.drop(
+            [
+                "Date",
+                "MarkDown1",
+                "MarkDown2",
+                "MarkDown3",
+                "MarkDown4",
+                "MarkDown5",
+                "Fuel_Price",
+            ],
+            axis=1,
+            inplace=True,
+        )
+
+        df = df.assign(IsHoliday=lambda df: df.IsHoliday.map({False: "no", True: "yes"}))
+        df = df[df["Weekly_Sales"] > 0]
+
+        df = stratify(df,groupby_cols=['Store', 'Dept'])
+        df = df.rename(columns=col_dict)
+
+        df_train, df_val = train_test_split(df,test_size=0.1,stratify=df[["store number","department number"]])
+        
+
+        numerical_features = [
+            "average temperature (in Fahrenheit)",
+            "consumer price index",
+            "unemployment rate",
+            "store size (in square feet)",
+        ]
+        categorical_features = df_train.columns[
+            (df_train.columns != "Weekly_Sales") & ~(df_train.columns.isin(numerical_features))
+        ].tolist()
+
+        self.setup_scaler(numerical_features)
+        self.scale_columns(df_train, mode='train')
+        self.scale_columns(df_val)
+
+        self.df_train = df_train
+        self.df_val = df_val
+        self.numerical_features = numerical_features
+        self.categorical_features = categorical_features
+        self.set_target_column(main_target='Weekly_Sales')
+
+
+
+
+

--- a/tabgpt/tabular_dataset.py
+++ b/tabgpt/tabular_dataset.py
@@ -1,34 +1,69 @@
+from tabgpt.col_embed import add_positional_info, remove_index
 import torch
 import numpy as np
 from torch.utils.data import Dataset, ConcatDataset
 import os
 import logging
+from IPython import embed
+import json
+
 
 
 class TabularDataset(Dataset):
-    def __init__(self, folder_path):
+    def __init__(self, folder_path, task_description_path,n_targets):
         self.folder_path = folder_path
         self.file_names = os.listdir(folder_path)
         # Sort the file names by the extracted index
         self.sorted_files = sorted(self.file_names, key=self.extract_index)
 
+        self.n_targets = n_targets
+
+        with open(os.path.join(task_description_path,'task_description.json'), 'r') as f:
+            self.task_dict = json.load(f)
+
+        self.cache_files = {}
 
     def __len__(self):
-        return len(self.file_names)
+        return len(self.file_names) * self.n_targets
+
+    
+    def _load_file(self, file_path):
+        if self.cache_files:
+            # Load and cache the file if it's not already cached
+            if file_path not in self.file_cache:
+                data = torch.tensor(np.load(file_path))
+                self.file_cache[file_path] = data
+            return self.file_cache[file_path]
+        else:
+            # Load the image without caching
+            return torch.tensor(np.load(file_path))
 
     def __getitem__(self, idx):
-        file_path = os.path.join(self.folder_path, self.sorted_files[idx])
+        actual_idx = idx // self.n_targets
+        augment_idx = idx % self.n_targets
+        file_path = os.path.join(self.folder_path, self.sorted_files[actual_idx])
 
-        data = torch.tensor(np.load(file_path))
+        data = self._load_file(file_path)
 
         # Extract label from the file name or other source
-        _, target = self.extract_info_from_filename(self.sorted_files[idx])
+        _, target_list = self.extract_info_from_filename(self.sorted_files[actual_idx])
+
+        target = torch.tensor(target_list[augment_idx][1],dtype=data.dtype)
+        data = self.prepare_data(data, augment_idx)
 
         return data, target
+    
+    def prepare_data(self, data, augment_idx):
+        keys = list(self.task_dict.keys())
+        c, target_embedding = self.task_dict[keys[augment_idx]]
+        target_embedding = torch.tensor(target_embedding,dtype=data.dtype)
+        data = add_positional_info(target_embedding=target_embedding, feature_embeddings=data)
+        return torch.cat((data[:c, :], data[(c+1):, :]), dim=0)
 
     def extract_info_from_filename(self, filename):
-        dataset_name, target, _ = filename.split(";")
-        return dataset_name, torch.tensor(float(target), dtype=torch.float32)
+        dataset_name, target_list, _ = filename.split(";")
+        target_list = eval(target_list)
+        return dataset_name, target_list
 
     def extract_index(self,file_name):
         return int(file_name.split(';')[-1].split('.')[0])
@@ -38,20 +73,13 @@ def join_paths(*paths):
     filtered_paths = [p for p in paths if p is not None]
     return os.path.join(*filtered_paths)
 
-def load_datasets(dataset_loader, mode, target=None, only_main=False):
+def load_datasets(dataset_loader, mode, only_main=False):
     datasets = []
     for d in dataset_loader:
-        ds_dir = os.path.join(join_paths(d.current_dir, 'files', mode, target))
-        if target is None and not only_main:
-            for i, target_col in enumerate(os.listdir(ds_dir)):
-                logging.info(f'Creating {mode} dataset {i} for {target_col}')
-                datasets.append(TabularDataset(os.path.join(ds_dir,target_col)))
-        elif target:
-            logging.info(f'Creating {mode} dataset for user-defined {target}')
-            datasets.append(TabularDataset(ds_dir))
-        else:
-            logging.info(f'Creating {mode} dataset for main-target {d.main_target}')
-            datasets.append(TabularDataset(os.path.join(ds_dir,d.main_target)))
+        ds_dir = os.path.join(join_paths(d.current_dir, 'files', mode))
+        datasets.append(TabularDataset(folder_path=ds_dir, 
+                                       task_description_path=os.path.join(d.current_dir, 'task_description', mode),
+                                       n_targets=len(d.target_column) if not only_main else 1))
             
     return ConcatDataset(datasets)
 

--- a/tabgpt/trainer.py
+++ b/tabgpt/trainer.py
@@ -16,6 +16,8 @@ from torch.utils.tensorboard import SummaryWriter
 from torch.optim.lr_scheduler import OneCycleLR
 import os
 import re
+import logging
+
 
 
 import warnings
@@ -65,7 +67,7 @@ class Trainer:
 
         # determine the device we'll train on
         if config.device == 'auto':
-            self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
+            self.device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
         else:
             self.device = config.device
         self.model = self.model.to(self.device)
@@ -134,6 +136,8 @@ class Trainer:
             for batch_idx, batch in progress_bar:
                 batch = [t.to(self.device) for t in batch]
                 x, y = batch
+                # backprop and update the parameters
+                model.zero_grad(set_to_none=True)
 
                 model.zero_grad(set_to_none=True)
 

--- a/tabgpt/utils.py
+++ b/tabgpt/utils.py
@@ -4,6 +4,7 @@ import sys
 import json
 import random
 from ast import literal_eval
+import pandas as pd
 
 import numpy as np
 import torch
@@ -130,3 +131,11 @@ def predict(model, dataloader, df, target_scaler):
 
     df["yhat"] = target_scaler.inverse_transform(np.array(yhat).reshape(-1, 1))
     return df
+
+
+def stratify(df, groupby_cols, sample_frac = 0.3, min_entries=100):
+    stratified_sample = df.groupby(groupby_cols, group_keys=False).apply(lambda x: x.sample(frac=sample_frac)).reset_index(drop=True)
+    group_counts = stratified_sample.groupby(groupby_cols).size().reset_index(name='counts')
+    valid_groups = group_counts[group_counts['counts'] >= min_entries]
+    filtered_sample = pd.merge(stratified_sample, valid_groups[groupby_cols], on=groupby_cols, how='inner')
+    return filtered_sample


### PR DESCRIPTION
This PR

1. adds some new datasets
2. changes the storage of files

**What has changed:**
We now treat every! column as feature, compute embeddings for each row and store as npy-file. The tensor that is stored has dimension (`n_cols, emb_dim`).  Within the file name, we store for each target its value and position in the sequence. So if `n_cols` is 10 and there are two targets at position 6 and 9, the file name contains `[6: 0.3, 9: 0.7]` with 0.3 and 0.7 being the respective target values for that particular row.  In addition, we store a dict containing the embedding for the task/target description of each target. 

In the torch dataset, we then:

- load the row-info (n_cols, emb_dim)
- load the dict
- prepend the target embedding (n_cols + 1, emb_dim)
- remove the target embedding

**Why this approach?** 

When training on multiple targets for a particular dataset, we stored one file per row per target, so with nrows = 100 and n_targts = 3 we stored 300 files. However, with the new approach, we only need to store 100 rows (plus the small dict)